### PR TITLE
Remove duplicate wostatus session assignment

### DIFF
--- a/maximo_app/views.py
+++ b/maximo_app/views.py
@@ -283,7 +283,6 @@ def index(request):
             request.session['wbs'] = wbs.wbs_code
             request.session['wbs_desc'] = wbs_desc
             request.session['worktype'] = worktype
-            request.session['wostatus'] = wostatus
             request.session['grouping_text'] = grouping_text
 
             try:


### PR DESCRIPTION
## Summary
- clean up redundant request.session assignment in index view

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68405a10402c8321a70e3afe5f7c0293